### PR TITLE
[CC] Improve IME support

### DIFF
--- a/packages/slate-react/src/components/content.js
+++ b/packages/slate-react/src/components/content.js
@@ -8,6 +8,7 @@ import omit from 'lodash/omit'
 import { List } from 'immutable'
 import {
   IS_ANDROID,
+  IS_CHROME,
   IS_FIREFOX,
   HAS_INPUT_EVENTS_LEVEL_2,
 } from 'slate-dev-environment'
@@ -454,8 +455,18 @@ class Content extends React.Component {
     // at the end of a block. The selection ends up to the left of the inserted
     // character instead of to the right. This behavior continues even if
     // you enter more than one character. (2019/01/03)
-    if (!IS_ANDROID && handler === 'onSelect') {
-      const { editor } = this.props
+    //
+    // CHROME: The updateSelection causes similar issues to Android with IME.
+    // cf. https://github.com/ianstormtaylor/slate/pull/3126
+    const skipUpdate = IS_ANDROID || (IS_CHROME && HAS_INPUT_EVENTS_LEVEL_2)
+    const { editor } = this.props
+
+    if (
+      !skipUpdate &&
+      // cf. https://github.com/ianstormtaylor/slate/pull/2454
+      !editor.isComposing &&
+      handler === 'onSelect'
+    ) {
       const { value } = editor
       const { selection } = value
       const window = getWindow(event.target)

--- a/packages/slate-react/src/plugins/dom/after.js
+++ b/packages/slate-react/src/plugins/dom/after.js
@@ -109,6 +109,9 @@ function AfterPlugin(options = {}) {
         break
       }
 
+      // cf. https://github.com/ianstormtaylor/slate/issues/2368#issuecomment-545033238
+      // cf. https://github.com/ianstormtaylor/slate/pull/3126
+      case 'insertFromComposition':
       case 'insertFromYank':
       case 'insertReplacementText':
       case 'insertText': {

--- a/packages/slate-react/src/plugins/dom/before.js
+++ b/packages/slate-react/src/plugins/dom/before.js
@@ -504,7 +504,11 @@ function BeforePlugin() {
     onKeyDown,
     onPaste,
     onSelect,
-    queries: { userActionPerformed },
+    queries: {
+      // cf. https://github.com/ianstormtaylor/slate/pull/2415/files#r232777986
+      isComposing: () => isComposing,
+      userActionPerformed,
+    },
     commands: { clearUserActionPerformed },
   }
 }


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing IME bugs

#### What's the new behavior?

1. Caret stays at correct location during IME input.
2. `insertFromComposition` event handled properly.

#### How does this change work?

Cobbles together proposed fixes from the following issues/pull requests/comments:
- https://github.com/ianstormtaylor/slate/pull/2415/files#r232777986
- https://github.com/ianstormtaylor/slate/pull/2454/files#diff-021b2a72cf52cd5e8214d0a035b3ebc9R351
- https://github.com/ianstormtaylor/slate/pull/3126/files#diff-021b2a72cf52cd5e8214d0a035b3ebc9R488
- https://github.com/ianstormtaylor/slate/issues/2368#issuecomment-545033238
- https://github.com/ianstormtaylor/slate/pull/3126/files#diff-66ff60bf0ae1c9b0d0ef4497bbe44cebR111

#### Have you checked that...?

<!--
Please run through this checklist for your pull request:
-->

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
