### PR TITLE
More IME fixes

### DIFF
--- a/packages/slate-react/src/plugins/dom/before.js
+++ b/packages/slate-react/src/plugins/dom/before.js
@@ -375,7 +375,8 @@ function BeforePlugin() {
    */
 
   function onInput(event, editor, next) {
-    if (isComposing) return
+    // let AfterPlugin have a crack at composition-related input events
+    if (isComposing) return editor.command('onCompositionInput', event)
     if (editor.value.selection.isBlurred) return
     isUserActionPerformed = true
     debug('onInput', { event })


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixing bugs:
1. CHROME: fix click away from active IME composition should commit composition
2. fix popup input palette sometimes inserts incorrect (stale) composition

#### What's the new behavior?

1. CHROME: Clicking away from in-progress composition accepts/commits the composition
2. Selecting from popup IME input palette inserts correct composition

#### How does this change work?

1. Brings in CHROME-only code from master branch to call `insertText()` upon receipt of `onCompositionEnd()`.
2. Tracks `insertCompositionText` to make sure that we're inserting the most recent state of the composition.

#### Have you checked that...?

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
