### PR TITLE
Add `setUserActionPerformed()` command

### DIFF
--- a/packages/slate-react/src/plugins/dom/before.js
+++ b/packages/slate-react/src/plugins/dom/before.js
@@ -479,6 +479,10 @@ function BeforePlugin() {
     return null
   }
 
+  function setUserActionPerformed() {
+    isUserActionPerformed = true
+  }
+
   /**
    * Return the plugin.
    *
@@ -510,7 +514,10 @@ function BeforePlugin() {
       isComposing: () => isComposing,
       userActionPerformed,
     },
-    commands: { clearUserActionPerformed },
+    commands: {
+      clearUserActionPerformed,
+      setUserActionPerformed,
+    },
   }
 }
 


### PR DESCRIPTION
#### Is this adding or improving a _feature_ or fixing a _bug_?

Adding a feature

#### What's the new behavior?

Adds `setUserActionPerformed()` command. There is already a corresponding `clearUserActionPerformed()` command. The use case here is that clicks on the toolbar should be considered user actions, but currently are not. In the normal course of events, `componentDidUpdate()` calls `updateSelection()` which calls `scrollToSelection()` to make sure that the insertion caret is currently visible. But `scrollToSelection()` is only called if `userActionPerformed` is true, and so formatting changes which are triggered from the toolbar can result in the caret being scrolled out of view.

#### How does this change work?

It simply adds a `setUserActionPerformed()` command. It is up to clients to call it appropriately.

#### Have you checked that...?

- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
