### PR TITLE
[CC] Support clipboard operations on images/chips

### DIFF
--- a/packages/slate-react/package.json
+++ b/packages/slate-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@concord-consortium/slate-react",
   "description": "A set of React components for building completely customizable rich-text editors.",
-  "version": "0.22.10-cc.3",
+  "version": "0.22.10-cc.4",
   "license": "MIT",
   "repository": "https://github.com/concord-consortium/slate",
   "main": "lib/slate-react.js",

--- a/packages/slate-react/src/components/content.js
+++ b/packages/slate-react/src/components/content.js
@@ -389,7 +389,8 @@ class Content extends React.Component {
    * @return {Boolean}
    */
 
-  isInEditor = target => {
+  // [CC] Allow clients to override isContentEditable requirement
+  isInEditor = (target, isContentEditableRequired = true) => {
     let el
 
     try {
@@ -415,7 +416,7 @@ class Content extends React.Component {
     }
 
     return (
-      el.isContentEditable &&
+      (el.isContentEditable || !isContentEditableRequired) && // [CC]
       (el === this.ref.current ||
         el.closest(SELECTORS.EDITOR) === this.ref.current)
     )
@@ -512,7 +513,15 @@ class Content extends React.Component {
       handler === 'onPaste' ||
       handler === 'onSelect'
     ) {
-      if (!this.isInEditor(event.target)) {
+      // [CC] Don't require `isContentEditable` in `isInEditor` for clipboard
+      const isContentEditableRequired = ![
+        'onCopy',
+        'onCut',
+        'onPaste',
+      ].includes(handler) // [/CC]
+
+      // [CC] Don't require `isContentEditable` in `isInEditor` for clipboard
+      if (!this.isInEditor(event.target, isContentEditableRequired)) {
         return
       }
     }

--- a/packages/slate-react/src/utils/clone-fragment.js
+++ b/packages/slate-react/src/utils/clone-fragment.js
@@ -69,7 +69,15 @@ function cloneFragment(event, editor, callback = () => undefined) {
   // attaching it to empty `<div>/<span>` nodes will end up having it erased by
   // most browsers. (2018/04/27)
   if (startVoid) {
-    attach = contents.childNodes[0].childNodes[1].firstChild
+    attach =
+      // [CC] The original slate code in the subsequent line assumes that the
+      // void "content" node is in a specific location in the DOM relative to
+      // the selected contents. This assumption is incorrect in the case of
+      // our void nodes like images and chips. Rather than hard-code another
+      // relationship, we require clients to add the `cc-slate-void` class to
+      // the void "content" node so it's easy to find.
+      contents.querySelector('.cc-slate-void') || // [/CC]
+      contents.childNodes[0].childNodes[1].firstChild
   }
 
   // Remove any zero-width space spans from the cloned DOM so that they don't


### PR DESCRIPTION
Support clipboard operations on selections of a single void node (e.g. image or variable chip).

Cut/copy/paste operations were ignored from selections that contained a single void node, i.e. an image or a variable chip. This is because in `onEvent`, certain events (including clipboard operations) are ignored when `isContentEditable` is false, which is the case when the selection contains only a void node. The first change is to allow the `isContentEditable` check to be bypassed for clipboard operations. This reveals the next problem, which is that the existing code for copying the selection to the clipboard doesn't work for selections that contain a single void node.

Therefore, the second change is to the `cloneFragment()` function, which had a hard-coded assumption about where to find the `content` DOM element for a void node which is not correct for our image or variable chip nodes. Rather than hard-code another assumption the layout of the DOM we instead require our void nodes to apply the `slate-void` class to the DOM element that should be considered the `content`.

Note that this change isn't testable on its own but I have tested it in conjunction with `slate-editor` library changes and the basic functionality works. There are still some things that don't work quite right, e.g. after pasting an image or variable chip the caret is placed before the pasted node rather than after it, but the behavior works well enough to be a clear improvement and it's unclear how long it would take to track down some of the remaining issues, so I'm inclined to merge this and we can log any remaining issues in PT for future prioritization.

**Checks**
- [x] The new code matches the existing patterns and styles.
- [x] The tests pass with `yarn test`.
- [x] The linter passes with `yarn lint`. (Fix errors with `yarn fix`.)
- [x] The relevant examples still work. (Run examples with `yarn start`.)

