### PR TITLE
slate-react 0.22.10-cc.5

### DIFF
--- a/packages/slate-react/Changelog.md
+++ b/packages/slate-react/Changelog.md
@@ -4,6 +4,9 @@ This document maintains a list of changes to the `slate-react` package with each
 
 ---
 
+### `0.22.10-cc.5` — July 6, 2022
+
+Replace dependency `slate-react-placeholder` with dependency `@concord-consortium/slate-react-placeholder` with updated `peerDependencies`.
 ### `0.22.10-cc.2` — July 16, 2020
 
 ###### FIXED

--- a/packages/slate-react/package.json
+++ b/packages/slate-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@concord-consortium/slate-react",
   "description": "A set of React components for building completely customizable rich-text editors.",
-  "version": "0.22.10-cc.4",
+  "version": "0.22.10-cc.5",
   "license": "MIT",
   "repository": "https://github.com/concord-consortium/slate",
   "main": "lib/slate-react.js",
@@ -13,6 +13,7 @@
     "lib/"
   ],
   "dependencies": {
+    "@concord-consortium/slate-react-placeholder": "^0.2.9-cc.1",
     "debug": "^3.1.0",
     "get-window": "^1.1.1",
     "is-window": "^1.0.2",
@@ -26,7 +27,6 @@
     "slate-hotkeys": "^0.2.9",
     "slate-plain-serializer": "^0.7.11",
     "slate-prop-types": "^0.5.42",
-    "slate-react-placeholder": "^0.2.9",
     "tiny-invariant": "^1.0.1",
     "tiny-warning": "^0.0.3"
   },
@@ -34,7 +34,7 @@
     "immutable": ">=3.8.1 || >4.0.0-rc",
     "react": ">=16.6.0",
     "react-dom": ">=16.6.0",
-    "slate": ">=0.47.0"
+    "slate": "^0.47.9"
   },
   "devDependencies": {
     "immutable": "^3.8.1",


### PR DESCRIPTION
* Fix`peerDependencies`
* Replace dependency `slate-react-placeholder` with `@concord-consortium/slate-react-placeholder` with updated `peerDependencies`. 