### PR TITLE
Release @concord-consortium/slate-react 0.22.10-cc.6

### DIFF
--- a/packages/slate-react/package.json
+++ b/packages/slate-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@concord-consortium/slate-react",
   "description": "A set of React components for building completely customizable rich-text editors.",
-  "version": "0.22.10-cc.5",
+  "version": "0.22.10-cc.6",
   "license": "MIT",
   "repository": "https://github.com/concord-consortium/slate",
   "main": "lib/slate-react.js",
@@ -44,7 +44,9 @@
     "slate-hyperscript": "^0.13.9"
   },
   "scripts": {
-    "clean": "rm -rf ./dist ./lib ./node_modules"
+    "clean": "rm -rf ./dist ./lib ./node_modules",
+    "publish:cc:dry-run": "npm publish --dry-run --access=public",
+    "publish:cc": "npm publish --access=public"
   },
   "umdGlobals": {
     "immutable": "Immutable",

--- a/packages/slate-react/src/components/content.js
+++ b/packages/slate-react/src/components/content.js
@@ -10,6 +10,8 @@ import {
   IS_ANDROID,
   IS_CHROME,
   IS_FIREFOX,
+  IS_IOS,
+  IS_SAFARI,
   HAS_INPUT_EVENTS_LEVEL_2,
 } from 'slate-dev-environment'
 import Hotkeys from 'slate-hotkeys'
@@ -597,7 +599,9 @@ class Content extends React.Component {
       // COMPAT: In iOS, a formatting menu with bold, italic and underline
       // buttons is shown which causes our internal value to get out of sync in
       // weird ways. This hides that. (2016/06/21)
-      ...((readOnly || (!IS_IOS && !IS_SAFARI)) ? {} : { WebkitUserModify: 'read-write-plaintext-only' }),
+      ...(readOnly || (!IS_IOS && !IS_SAFARI)
+        ? {}
+        : { WebkitUserModify: 'read-write-plaintext-only' }),
       // [CC] https://github.com/ianstormtaylor/slate/issues/5110#issuecomment-1236831747
       // Allow for passed-in styles to override anything.
       ...props.style,


### PR DESCRIPTION
- fix Chrome 105 issues
- add publishing scripts

#### Is this adding or improving a _feature_ or fixing a _bug_?

Fixes bugs introduced with Chrome 105

#### What's the new behavior?

#### How does this change work?

#### Have you checked that...?

<!-- 
Please run through this checklist for your pull request: 
-->

* [x] The new code matches the existing patterns and styles.
* [x] The tests pass with `yarn test`.
* [x] The linter passes with `yarn lint`. (Fix errors with `yarn prettier`.)
* [x] The relevant examples still work. (Run examples with `yarn watch`.)

#### Does this fix any issues or need any specific reviewers?

Fixes: #
Reviewers: @
